### PR TITLE
Strip Selection Defaults To First Strip

### DIFF
--- a/js/views/Wizard.jsx
+++ b/js/views/Wizard.jsx
@@ -108,7 +108,7 @@ export default class Wizard extends React.Component {
     let Strips = board.get('strips').map((strip, key) => {
       return (
         <li key={strip.cid}>
-          <StripPanel strip={strip} removeStrip={this.removeStrip.bind(this)}></StripPanel>
+          <StripPanel id={key} strip={strip} removeStrip={this.removeStrip.bind(this)}></StripPanel>
         </li>
       )
     })


### PR DESCRIPTION
Fixes an issue where clicking on a strip to expand it results in the first strip getting selected all the time. 

Resolves the problem by passing in an id to the strip component. 
